### PR TITLE
Build sdist and wheels in GHA and upload to PyPI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,93 @@
+name: Build and upload to PyPI
+
+# Based upon: https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - omad
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+        - os: linux-intel
+          runs-on: ubuntu-latest
+        - os: linux-arm
+          runs-on: ubuntu-24.04-arm
+        - os: windows-intel
+          runs-on: windows-latest
+        - os: windows-arm
+          runs-on: windows-11-arm
+        - os: macos-intel
+          # macos-13 was the last x86_64 runner
+          runs-on: macos-13
+        - os: macos-arm
+          # macos-14+ (including latest) are ARM64 runners
+          runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.1.4
+        env:
+          CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
+        # env:
+        #   CIBW_SOME_OPTION: value
+        #   ...
+        # with:
+        #   package-dir: .
+        #   output-dir: wheelhouse
+        #   config-file: "{package}/pyproject.toml"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        # with:
+          # To test: repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,11 +14,19 @@ on:
 
 permissions: {}
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
+      # Allow jobs to continue even if one fails to build
+      fail-fast: false
       matrix:
         include:
         - os: linux-intel
@@ -36,12 +44,12 @@ jobs:
           # macos-14+ (including latest) are ARM64 runners
           runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
         # env:
@@ -52,7 +60,7 @@ jobs:
         #   output-dir: wheelhouse
         #   config-file: "{package}/pyproject.toml"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -61,12 +69,14 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -81,13 +91,12 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        # with:
-          # To test: repository-url: https://test.pypi.org/legacy/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,8 +25,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
-      # Allow jobs to continue even if one fails to build
-      fail-fast: false
+      # fail-fast: false # Allow jobs to continue even if one fails to build
       matrix:
         include:
         - os: linux-intel
@@ -35,14 +34,17 @@ jobs:
           runs-on: ubuntu-24.04-arm
         - os: windows-intel
           runs-on: windows-latest
-        - os: windows-arm
-          runs-on: windows-11-arm
-        - os: macos-intel
-          # macos-13 was the last x86_64 runner
-          runs-on: macos-13
-        - os: macos-arm
-          # macos-14+ (including latest) are ARM64 runners
-          runs-on: macos-latest
+      # - Windows ARM and MacOS builds are currently broken.
+      # - MacOS at least will be fixed, it requires making libomp available
+      #   in a way that allows compiling and distributing
+        # - os: windows-arm
+        #   runs-on: windows-11-arm
+        # - os: macos-intel
+        #   # macos-13 was the last x86_64 runner
+        #   runs-on: macos-13
+        # - os: macos-arm
+        #   # macos-14+ (including latest) are ARM64 runners
+        #   runs-on: macos-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -52,13 +54,6 @@ jobs:
         uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
-        # env:
-        #   CIBW_SOME_OPTION: value
-        #   ...
-        # with:
-        #   package-dir: .
-        #   output-dir: wheelhouse
-        #   config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
     branches: [ "main" ]
 
 permissions: {}
-  # contents: read
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
+permissions: {}
+  # contents: read
 
 jobs:
   build:
@@ -21,9 +21,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false
     - name: Set up Python multi-version (3.10-3.13)
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
This adds a GitHub Actions workflow that uses [cibuildwheel](https://cibuildwheel.pypa.io/) to build distributable binary wheels, as well as an sdist.

At the moment I have it configured for:
- Linux ARM
- Linux x64
- Windows x64 and x32

The Workflow is broken into 3 steps, and uploads Artifacts through GitHub Actions which can be downloaded after the run has complete.

If the run was trigged by creating a GitHub Release it will attempt to upload them to PyPI using OIDC for authentication.


I still need to fix builds on MacOS. It works locally after I `brew install libomp` and set some environment variables. I want to do some more research about whether that will work in CI and create a useful binary that can be installed elsewhere before enabling it here.